### PR TITLE
README and parity between exactness modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # DandD  
-A tool to estimate deltas for sequence sets and answer questions about relative contribution. DandD can be used to addresses how much new sequence is gained when a sequence collection grows and describe how much structural variation is discovered in each new human genome assembly allowing prediction of when discoveries will level off in the future. DandD uses a measure called $\delta$ (“delta”), developed initially for data compression and chiefly dependent on k-mer counts. DandD rapidly estimates $\delta$ using genomic sketches. Further information about the use of delta to address sequence similarity and how it is implemented in DandD can be found in the associated publication in iScience Volume 27, Issue 3, 15 March 2024, 109054.\\
- Jessica K. Bonnie, Omar Y. Ahmed, Ben Langmead. **DandD: efficient measurement of sequence growth and similarity**
- <https://www.sciencedirect.com/science/article/pii/S258900422400275X>, iScience<https://www.sciencedirect.com/journal/iscience> 10.1016/j.isci.2024.109054<https://doi.org/10.1016/j.isci.2024.109054>
+A tool to estimate deltas for sequence sets and answer questions about relative contribution. DandD can be used to addresses how much new sequence is gained when a sequence collection grows and describe how much structural variation is discovered in each new human genome assembly allowing prediction of when discoveries will level off in the future. DandD uses a measure called $\delta$ (“delta”), developed initially for data compression and chiefly dependent on k-mer counts. DandD rapidly estimates $\delta$ using genomic sketches. Further information about the use of delta to address sequence similarity and how it is implemented in DandD can be found in the associated publication in iScience Volume 27, Issue 3, 15 March 2024, 109054.
+
+ Jessica K. Bonnie, Omar Y. Ahmed, Ben Langmead. [**DandD: efficient measurement of sequence growth and similarity**]
+ (https://www.sciencedirect.com/science/article/pii/S258900422400275X), [iScience](https://www.sciencedirect.com/journal/iscience) [10.1016/j.isci.2024.109054](https://doi.org/10.1016/j.isci.2024.109054)
  
 
 ## Installation  

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # DandD  
-Tool to estimate deltas for sequence sets and answer questions about relative contribution
+A tool to estimate deltas for sequence sets and answer questions about relative contribution. DandD can be used to addresses how much new sequence is gained when a sequence collection grows and describe how much structural variation is discovered in each new human genome assembly allowing prediction of when discoveries will level off in the future. DandD uses a measure called $\delta$ (“delta”), developed initially for data compression and chiefly dependent on k-mer counts. DandD rapidly estimates $\delta$ using genomic sketches. Further information about the use of delta to address sequence similarity and how it is implemented in DandD can be found in the associated publication in iScience Volume 27, Issue 3, 15 March 2024, 109054.\\
+ Jessica K. Bonnie, Omar Y. Ahmed, Ben Langmead. **DandD: efficient measurement of sequence growth and similarity**
+ <https://www.sciencedirect.com/science/article/pii/S258900422400275X>, iScience<https://www.sciencedirect.com/journal/iscience> 10.1016/j.isci.2024.109054<https://doi.org/10.1016/j.isci.2024.109054>
+ 
 
 ## Installation  
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -64,8 +64,10 @@ If we wish to calculate the K-Independent Jaccard (KIJ) for our set, we use the 
 ```
 
 ### K-Sweep
-In the paper we analyze what potential values of the delta ratio were considered in order to compare its growth to other measures as well as illustrate the selection of the argmax-k. In order to accomplish this, we used the `--ksweep` command to produce all potential values of delta for ks within a specific range. Again we provide a window of `--mink` and `--maxk`. Depending on which pickle we provide we can sweep bare sketches with unions or every union performed in a progressive union. In the command below we do the latter:
+In the paper we analyze what potential values of the delta ratio were considered in order to compare its growth to other measures as well as illustrate the selection of the argmax-k. In order to accomplish this, we used the `--ksweep` command to produce all potential values of delta for ks within a specific range. Again we provide a window of `--mink` and `--maxk`. Depending on which subcommand we provide we can sweep bare sketches with unions or every union performed in a progressive union. In the command below we do the latter:
 
 ```
-../lib/dandd kij --ksweep --dtree /home/jbonnie1/dandd/dev-dandD/example/small_fish_progu30_5_dashing_dtree.pickle
+../lib/dandd progressive --ksweep --dtree /home/jbonnie1/dandd/dev-dandD/example/small_fish_progu30_5_dashing_dtree.pickle
 ```
+### Exactitude with KMC3
+If you wish to count kmers rather than estimate with dashing, you would adjust your `tree` subcommand at the beginning to use the `--exact` argument. All files output after this change will replace the word "dashing" with "kmc" in their output filenames.

--- a/example/README.md
+++ b/example/README.md
@@ -21,30 +21,36 @@ The first step will be to create intial sketches of the fasta files and find del
 ```
 The table of delta values for the sketches is saved to: `fish-mito_25_dashing_deltas.csv`. The `sketchdb` directory contains the dashing sketches pertaining to everything run in this output directory, as well as the `fastahex.pickle` and `sketchinfo.pickle` with metadata for DandD to track them. For a human readable table tracking the fastas and their associated sketches for each experiment see `fish-mito_25_dashing_sketchdb.txt`. (`{experiment_tag}_{#fastas}_{tool}_sketchdb.txt`)
 
-## Children
-DandD will default to unioning all of the sketches/databases at once to obtain n+1 deltas. You can also ask it to combine them in a tree-like manner by indicating the maximum number of childnodes that should be combined at each level.
+If you would rather provide a list of global paths to the input fastas rather than a directory, the following command will produce the same results as above. If both commands are run, observe that no additional sketches need to be produced.
 ```
-../lib/dandd tree --datadir ./assembled-fish_mito --tag fish-mito --nchildren 2
+realpath ./assembled-fish_mito/* > fish_list.txt
+../lib/dandd tree --fastas fish_list.txt --tag fish-mito
+```
+
+## Children
+DandD will default to unioning all of the sketches/databases at once to obtain n+1 deltas. You can also ask it to combine them in a tree-like manner by indicating the maximum number of childnodes that should be combined at each level. In this example we also instruct DandD to start looking for the optimal k at `k=12`. Note that the initial sketches of the individual fastas were created during the previous example, so all that is needed is to produce the desired unions. You will observe that the output file `fish-mito_25_dashing_deltas.csv` has around twice as many lines containing delta values as in the previous command because the deltas for the additional intermediate unionsare also reported.
+```
+../lib/dandd tree --datadir ./assembled-fish_mito --tag fish-mito2 --nchildren 2 -k 12
 ```
 
 ## SubTree
-Suppose you are only interested in a subset of the fastas for a particular experiment? You can do that too! DandD will use the sketches already produced to create this smaller tree. You will note that the only sketching/kmer counting being performed is on the union of the subset.  
+Suppose you are only interested in a subset of the fastas for a particular experiment? You can do that too! DandD will use the sketches already produced to create this smaller tree. You will note that the only sketching/kmer-counting being performed is on the union of the subset, since no `--nchildren` value is indicated and all individual fasta sketches already exist at the relative values of k.  
 
 ```
 realpath ./assembled-fish_mito/* | head -n5 > fish_subset.txt
 ../lib/dandd tree --fastas fish_subset.txt --tag small_fish -k 12
 
 ```
-The table of delta values for the sketches is saved to: `small_fish_5_dashing_deltas.csv`. The pickle of the delta-tree object is saved to: `small_fish_5_dashing_dtree.pickle`.
+The table of delta values for the sketches is saved to: `small_fish_5_dashing_deltas.csv`. The pickle of the delta-tree object is saved to: `small_fish_5_dashing_dtree.pickle`. The number of input fastas is always included in these output files.
 
 ## Progressive Union
 
-We can run the progressive union on either the full set or the subset. Here we run it on the subset, since a lower number of samples means less permutations would be needed to get a look at the pattern. We start with 10 orderings. DandD will create a default file prefix from the tag name of the tree and the number of orderings, but this can also be provided.
+We can run the progressive union on either the full set or the subset. Here we run it on the subset, since a lower number of samples means less permutations would be needed to get a look at the pattern. We start with 10 orderings. DandD will create a default file prefix from the tag name of the tree and the number of orderings to output a summary file containing the values of delta for each progressive combination for each ordering. The output file will be named `small_fish_progu10_5_dashingsummary.csv`.
 ```
 ../lib/dandd progressive --dtree small_fish_5_dashing_dtree.pickle --norder 10 
 ```
 
-This creates `sketchdb/small_fish_5_orderings.pickle` containing the orderings. It might be the case that these orderings are desired to be used for a parallel dataset (say the same samples stratified by variant type, as in the paper). Alternatively, this allows for reproduction of these initial orderings when additional orderings are added in a later run:
+This creates the internal file `sketchdb/small_fish_5_orderings.pickle` containing the orderings. It might be the case that these orderings are desired to be used for a parallel dataset (say the same samples stratified by variant type, as in the paper). Alternatively, this allows for reproduction of these initial orderings when additional orderings are added in a later run. In the command below another 20 orderings are stacked on top of the original 10 to produe a file called `small_fish_progu30_5_dashingsummary.csv`:
 
 ```
 ../lib/dandd progressive --dtree small_fish_5_dashing_dtree.pickle --norder 30 
@@ -55,4 +61,11 @@ If we wish to calculate the K-Independent Jaccard (KIJ) for our set, we use the 
 
 ```
 ../lib/dandd kij --dtree small_fish_5_dashing_dtree.pickle
+```
+
+### K-Sweep
+In the paper we analyze what potential values of the delta ratio were considered in order to compare its growth to other measures as well as illustrate the selection of the argmax-k. In order to accomplish this, we used the `--ksweep` command to produce all potential values of delta for ks within a specific range. Again we provide a window of `--mink` and `--maxk`. Depending on which pickle we provide we can sweep bare sketches with unions or every union performed in a progressive union. In the command below we do the latter:
+
+```
+../lib/dandd kij --ksweep --dtree /home/jbonnie1/dandd/dev-dandD/example/small_fish_progu30_5_dashing_dtree.pickle
 ```

--- a/lib/sketch_classes.py
+++ b/lib/sketch_classes.py
@@ -410,7 +410,9 @@ class KMCSketchObj(SketchObj):
             # if self.check_cardinality() > 0:
                 # return True
         if (os.path.exists(path +".kmc_pre")) and (os.path.exists(path +".kmc_suf")) and os.stat(path +".kmc_suf").st_size != 0 and os.stat(path +".kmc_pre").st_size != 0:
-            return True
+            if self.check_cardinality() > 0:
+                return True
+            return False
         else:
             return False
         


### PR DESCRIPTION
Update to example README and correction to error detection for KMC cardinality command. Superclass function now works for both dashing and kmc.